### PR TITLE
Fix interop issue with mpv-gallery-view

### DIFF
--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -282,7 +282,7 @@ function Thumbnailer:register_client()
 
         if self.state.available and thumbnailer_options.autogenerate then
             -- Notify if autogenerate is on and video is not too long
-            if duration < max_duration or max_duration == 0 then
+            if duration ~= nil and duration < max_duration or max_duration == 0 then
                 self:start_worker_jobs()
             end
         end


### PR DESCRIPTION
I am quite new to mpv and may have done this fix incorrectly. Please check before merging.

After installing both [occivink/mpv-gallery-view](https://github.com/occivink/mpv-gallery-view) and  this plugin, error will be thrown when gallery view is launched.

Traceback:
```
[mpv_thumbnail_script_client_osc]
[mpv_thumbnail_script_client_osc] stack traceback:
[mpv_thumbnail_script_client_osc]       .../.config/mpv/scripts/mpv_thumbnail_script_client_osc.lua:1080: in function 'prop'
[mpv_thumbnail_script_client_osc]       mp.defaults:365: in function 'handler'
[mpv_thumbnail_script_client_osc]       mp.defaults:458: in function 'call_event_handlers'
[mpv_thumbnail_script_client_osc]       mp.defaults:495: in function 'dispatch_events'
[mpv_thumbnail_script_client_osc]       mp.defaults:451: in function <mp.defaults:450>
[mpv_thumbnail_script_client_osc]       [C]: in ?
[mpv_thumbnail_script_client_osc]       [C]: in ?
[mpv_thumbnail_script_client_osc] Lua error: .../.config/mpv/scripts/mpv_thumbnail_script_client_osc.lua:1080: attempt to compare nil with number
```

This patch add nil check on duration variable and fix the issue.

---

Other than this issue, I got issue with thumbnail generation on short video (Videos that will generate less than 150 thumbnails, which is the `thumbnail_count` config)

Mpv log says `output file missing` while the log file for converter says the following:
```
[   0.080][v][mkv] EOF reached.
[   0.106][v][cplayer] video EOF reached
[   0.106][v][cplayer] playback restart complete
[   0.106][v][cplayer] EOF code: 1
[   0.106][v][vd] Uninit video.
[   0.107][v][cplayer] finished playback, no audio or video data played (reason 4)
[   0.107][i][cplayer]
[   0.107][i][cplayer]
[   0.107][i][cplayer] Exiting... (Errors when loading file)
```

I am not sure if that is my fault or issue with server module.

Thanks