### PR TITLE
Fix typo ('unavailabe' -> 'unavailable')

### DIFF
--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -294,7 +294,7 @@ function Thumbnailer:register_client()
             mp.osd_message("Started thumbnailer jobs")
             self:start_worker_jobs()
         else
-            mp.osd_message("Thumbnailing unavailabe")
+            mp.osd_message("Thumbnailing unavailable")
         end
     end)
 end


### PR DESCRIPTION
Just what it says on the tin: a single character insertion.