### PR TITLE
Handle when duration is nil (ex. with playlist gallery script)

### DIFF
--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -282,7 +282,7 @@ function Thumbnailer:register_client()
 
         if self.state.available and thumbnailer_options.autogenerate then
             -- Notify if autogenerate is on and video is not too long
-            if duration < max_duration or max_duration == 0 then
+            if not duration == nil and duration < max_duration or max_duration == 0 then
                 self:start_worker_jobs()
             end
         end


### PR DESCRIPTION
When using [this](https://github.com/occivink/mpv-gallery-view) gallery view script, the thumbnail script will crash because there will be no video playing and the 'duration' variable will be nil. This commit fixes that issue.