### PR TITLE
Fix grammar and future-proof against new releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This allows you to preview the end of the file before every thumbnail has been g
 
 ## How do I install it?
 
-Grab both the two `.lua`s from the [**releases page**](https://github.com/TheAMM/mpv_thumbnail_script/releases) and place them both to your mpv's `scripts` directory.
+Grab the `.lua` files from the [**releases page**](https://github.com/TheAMM/mpv_thumbnail_script/releases) and place them in your mpv's `scripts` directory.
 
 For example:
   * Linux/Unix/Mac: `~/.config/mpv/scripts/mpv_thumbnail_script_server.lua` & `~/.config/mpv/scripts/mpv_thumbnail_script_client_osc.lua`


### PR DESCRIPTION
There was a grammatical redundancy in the phrase "both the two", so by generalizing the statement to any arbitrary number of .lua files we simultaneously fix this redundancy and future-proof the README against new releases, which might add or subtract a script file.