### PR TITLE
Add option to quit when done

### DIFF
--- a/src/options.lua
+++ b/src/options.lua
@@ -42,6 +42,9 @@ local thumbnailer_options = {
     -- Disable the built-in keybind ("T") to add your own
     disable_keybinds = false,
 
+    -- Quit mpv when thumbnails have been generated
+    quit_when_done = false,
+
     ---------------------
     -- Display options --
     ---------------------

--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -56,6 +56,10 @@ function Thumbnailer:on_thumb_ready(index)
             self.state.finished_thumbnails = self.state.finished_thumbnails + 1
         end
     end
+
+    if thumbnailer_options.quit_when_done and self.state.finished_thumbnails == self.state.thumbnail_count then
+       mp.commandv("quit")
+    end
 end
 
 function Thumbnailer:on_thumb_progress(index)


### PR DESCRIPTION
Motivation: make it possible to pre-generate thumbnails through automation.

For example, to generate thumbnails without outputting video nor audio:

```
$ mpv \                                                                                                                
      -vo null \                                                                                                         
      -ao null \                                                                                                         
      --no-osc \                                                                                                         
      --pause \                                                                                                          
      --script-opts=mpv_thumbnail_script-quit_when_done=yes \
      path/to/video
```
