### PR TITLE
Fix error "attempt to compare nil with number"

### DIFF
--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -280,7 +280,7 @@ function Thumbnailer:register_client()
         local duration = mp.get_property_native("duration")
         local max_duration = thumbnailer_options.autogenerate_max_duration
 
-        if self.state.available and thumbnailer_options.autogenerate then
+        if duration ~= nil and self.state.available and thumbnailer_options.autogenerate then
             -- Notify if autogenerate is on and video is not too long
             if duration < max_duration or max_duration == 0 then
                 self:start_worker_jobs()


### PR DESCRIPTION
This fixes an error that gets logged every time a video finishes playing:

```
...
[vd] Uninit decoder.
[client_osc]
[client_osc] stack traceback:
[client_osc]    mp.defaults:366: in function 'handler'
[client_osc]    mp.defaults:460: in function 'call_event_handlers'
[client_osc]    mp.defaults:494: in function 'dispatch_events'
[client_osc]    mp.defaults:453: in function <mp.defaults:452>
[client_osc]    [C]: at 0x5745da2c25d0
[client_osc]    [C]: at 0x5745da2c38d0
[client_osc] Lua error:
...jmrbar-mpv_thumbnail_script-0.4.2/scripts/client_osc.lua:1087:
attempt to compare nil with number
...
```

Tested on mpv version 0.29.0:

```
$ mpv --version
mpv 0.29.0-910-gd66eb93e5d Copyright © 2000-2019 mpv/MPlayer/mplayer2 projects
 built on Thu Oct 24 22:37:22 AKDT 2019
ffmpeg library versions:
   libavutil       56.35.101
   libavcodec      58.59.102
   libavformat     58.33.100
   libswscale      5.6.100
   libavfilter     7.65.100
   libswresample   3.6.100
ffmpeg version: N-95553-g155508c6e9
```
