### PR TITLE
server: Add equals operator in mpv options

### DIFF
--- a/src/thumbnailer_server.lua
+++ b/src/thumbnailer_server.lua
@@ -59,7 +59,7 @@ function create_thumbnail_mpv(file_path, timestamp, size, output_path, options)
         "--vf-add=format=bgra",
         "--of=rawvideo",
         "--ovc=rawvideo",
-        "--o", output_path
+        "--o=" .. output_path
     })
     return utils.subprocess({args=mpv_command})
 end


### PR DESCRIPTION
Following mpv-player/mpv@d3cef97, all options passed to mpv require
the format "mpv --o='path'" instead of "mpv --o 'path'". This change
should be backwards compatible with older mpv versions as well.