### PR TITLE
src/thumbnailer_shared.lua: hash remote URLs even if short

### DIFF
--- a/src/thumbnailer_shared.lua
+++ b/src/thumbnailer_shared.lua
@@ -129,8 +129,12 @@ function Thumbnailer:get_thumbnail_template()
     end
 
     filename = filename:gsub('[^a-zA-Z0-9_.%-\' ]', '')
-    -- Hash overly long filenames (most likely URLs)
-    if #filename > thumbnailer_options.hash_filename_length then
+
+    -- Hash remote URLs
+    if filesize == 0 then
+        filename = sha1.hex(file_path)
+    -- Hash overly long filenames
+    elseif #filename > thumbnailer_options.hash_filename_length then
         filename = sha1.hex(filename)
     end
 


### PR DESCRIPTION
This commit causes all remote/device URLs to be hashed so
URLs with filenames like watch or view.php will not
collide.