### PR TITLE
replace deprecated "lua-settings" directory with "script-opts"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Simply copy the `mpv_thumbnail_script_server.lua` once or twice (`mpv_thumbnail_
 This improves thumbnailing speed a bunch, but you will quickly max out your CPU - I recommend only having two or three copies of the script.  
 (Why multiple copies of the same file? mpv gives each script their own thread - easy multithreading!)
 
-To adjust the script's options, create a file called `mpv_thumbnail_script.conf` inside your mpv's `lua-settings` directory.
+To adjust the script's options, create a file called `mpv_thumbnail_script.conf` inside your mpv's `script-opts` directory.
 
 For example:
-  * Linux/Unix/Mac: `~/.config/mpv/lua-settings/mpv_thumbnail_script.conf`
-  * Windows: `%APPDATA%\mpv\lua-settings\mpv_thumbnail_script.conf`
+  * Linux/Unix/Mac: `~/.config/mpv/script-opts/mpv_thumbnail_script.conf`
+  * Windows: `%APPDATA%\mpv\script-opts\mpv_thumbnail_script.conf`
 
 (See the [Files section](https://mpv.io/manual/master/#files) in mpv's manual for more info.)
 


### PR DESCRIPTION
Using the currently suggested configuration directory results in a warning:
```
[mpv_thumbnail_script_server] lua-settings/ is deprecated, use directory script-opts/ 
[mpv_thumbnail_script_client_osc] lua-settings/ is deprecated, use directory script-opts/ 
```
This commit updates the README accordingly.